### PR TITLE
fix: open all links in a new tab

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,22 +1,31 @@
 import DOMPurify from 'dompurify';
-import marked from 'marked'
-import hjs from 'highlight.js'
+import marked from 'marked';
+import hjs from 'highlight.js';
+
+// force all links to open in a new tab
+DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+  // set all elements owning target to target=_blank
+  if ('target' in node) {
+    node.setAttribute('target', '_blank');
+  }
+  // set non-HTML/MathML links to xlink:show=new
+  if (!node.hasAttribute('target') && (node.hasAttribute('xlink:href') || node.hasAttribute('href'))) {
+    node.setAttribute('xlink:show', 'new');
+  }
+});
+
 marked.setOptions({
-  // breaks: true,
-  // gfm: true,
   highlight: function (code, lang) {
     const hljs = hjs;
     const language = hljs.getLanguage(lang) ? lang : 'plaintext';
     return hljs.highlight(code, { language }).value;
   },
   langPrefix: 'hljs language-', // highlight.js css expects a top-level 'hljs' class.
-})
+});
 
 export function parseCode(messageString: string) {
-  // const html = marked.parseInline(messageString);
   const html = marked(messageString);
   const sanitizedHtmlString = DOMPurify.sanitize(html);
 
   return sanitizedHtmlString;
 }
-


### PR DESCRIPTION
Fixes an issue where links clicked in the chat would open in the same tab. Now all links generated
should open in a new tab when clicked.
