### PR TITLE
fix(scrolling): don't rely on `scrollIntoView` for autoscroll

### DIFF
--- a/src/components/discord-mirror/discord-mirror.css
+++ b/src/components/discord-mirror/discord-mirror.css
@@ -8,6 +8,8 @@ ul.message-container {
   height: 100%;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 .username {


### PR DESCRIPTION
Simplifies the autoscroll behavior so that it primarily css based instead of using
`Element#scrollIntoView` which was inconsistent.
